### PR TITLE
Fix handing of files.

### DIFF
--- a/block_rolespecifichtml.php
+++ b/block_rolespecifichtml.php
@@ -116,7 +116,7 @@ class block_rolespecifichtml extends block_base {
 
         $config = clone($data);
         // Move embedded files into a proper filearea and adjust HTML links to match.
-        $config->text_all = file_save_draft_area_files($data->text_all['itemid'], $this->context->id, 'block_rolespecificthtml', 'content', 0, array('subdirs' => true), $data->text_all['text']);
+        $config->text_all = file_save_draft_area_files($data->text_all['itemid'], $this->context->id, 'block_rolespecifichtml', 'content', 0, array('subdirs' => true), $data->text_all['text']);
         $config->format_all = $data->text_all['format'];
 
         if (!$context) {
@@ -130,7 +130,7 @@ class block_rolespecifichtml extends block_base {
             foreach (array_values($roles) as $rid) {
                 $tk = 'text_'.$rid;
                 $fk = 'format_'.$rid;
-                $config->{$tk} = file_save_draft_area_files(@$data->{$tk}['itemid'], $this->context->id, 'block_rolespecificthtml', 'content', 0, array('subdirs' => true), @$data->{$tk}['text']);
+                $config->{$tk} = file_save_draft_area_files(@$data->{$tk}['itemid'], $this->context->id, 'block_rolespecifichtml', 'content', 0, array('subdirs' => true), @$data->{$tk}['text']);
                 $config->{$fk} = @$data->{$tk}['format'];
             }
         }

--- a/block_rolespecifichtml.php
+++ b/block_rolespecifichtml.php
@@ -77,7 +77,7 @@ class block_rolespecifichtml extends block_base {
             $this->config = new StdClass();
         }
 
-        $this->config->$tk = file_rewrite_pluginfile_urls(@$this->config->$tk, 'pluginfile.php', $this->context->id, 'block_rolespecifichtml', 'content', null);
+        $this->config->$tk = file_rewrite_pluginfile_urls(@$this->config->$tk, 'pluginfile.php', $this->context->id, 'block_rolespecifichtml', 'content_all', null);
         if (is_array($this->config->$tk)) {
             $arr = $this->config->$tk;
             $this->content->text .= !empty($arr['text']) ? format_text($arr['text'], $arr['format'], $filteropt) : '';
@@ -88,7 +88,7 @@ class block_rolespecifichtml extends block_base {
         if (!empty($roleids)) {
             foreach ($roleids as $roleid) {
                 $tk = "text_$roleid";
-                $this->config->$tk = file_rewrite_pluginfile_urls(@$this->config->$tk, 'pluginfile.php', $this->context->id, 'block_rolespecifichtml', 'content', null);
+                $this->config->$tk = file_rewrite_pluginfile_urls(@$this->config->$tk, 'pluginfile.php', $this->context->id, 'block_rolespecifichtml', 'content_' . $roleid, null);
                 if (is_array($this->config->$tk)) {
                     $arr = $this->config->$tk;
                     $this->content->text .= !empty($arr['text']) ? format_text($arr['text'], $arr['format'], $filteropt) : '';
@@ -116,7 +116,7 @@ class block_rolespecifichtml extends block_base {
 
         $config = clone($data);
         // Move embedded files into a proper filearea and adjust HTML links to match.
-        $config->text_all = file_save_draft_area_files($data->text_all['itemid'], $this->context->id, 'block_rolespecifichtml', 'content', 0, array('subdirs' => true), $data->text_all['text']);
+        $config->text_all = file_save_draft_area_files($data->text_all['itemid'], $this->context->id, 'block_rolespecifichtml', 'content_all', 0, array('subdirs' => true), $data->text_all['text']);
         $config->format_all = $data->text_all['format'];
 
         if (!$context) {
@@ -130,7 +130,7 @@ class block_rolespecifichtml extends block_base {
             foreach (array_values($roles) as $rid) {
                 $tk = 'text_'.$rid;
                 $fk = 'format_'.$rid;
-                $config->{$tk} = file_save_draft_area_files(@$data->{$tk}['itemid'], $this->context->id, 'block_rolespecifichtml', 'content', 0, array('subdirs' => true), @$data->{$tk}['text']);
+                $config->{$tk} = file_save_draft_area_files(@$data->{$tk}['itemid'], $this->context->id, 'block_rolespecifichtml', 'content_' . $rid, 0, array('subdirs' => true), @$data->{$tk}['text']);
                 $config->{$fk} = @$data->{$tk}['format'];
             }
         }

--- a/edit_form.php
+++ b/edit_form.php
@@ -118,7 +118,7 @@ class block_rolespecifichtml_edit_form extends block_edit_form {
                 $currenttext = $text_all;
             }
 
-            $defaults->config_text_all['text'] = file_prepare_draft_area($draftid_editor, $this->block->context->id, 'block_rolespecifichtml', 'content', 0, array('subdirs' => true), $currenttext);
+            $defaults->config_text_all['text'] = file_prepare_draft_area($draftid_editor, $this->block->context->id, 'block_rolespecifichtml', 'content_all', 0, array('subdirs' => true), $currenttext);
             $defaults->config_text_all['itemid'] = $draftid_editor;
             $defaults->config_text_all['format'] = @$this->block->config->format;
 
@@ -139,7 +139,7 @@ class block_rolespecifichtml_edit_form extends block_edit_form {
                         $currenttext = $this->block->config->$textvar;
                     }
 
-                    $defaults->{$configtextvar}['text'] = file_prepare_draft_area($draftid_editor, $this->block->context->id, 'block_rolespecifichtml', 'content', 0, array('subdirs' => true), $currenttext);
+                    $defaults->{$configtextvar}['text'] = file_prepare_draft_area($draftid_editor, $this->block->context->id, 'block_rolespecifichtml', 'content_' . $r->id, 0, array('subdirs' => true), $currenttext);
                     $defaults->{$configtextvar}['itemid'] = $draftid_editor;
                     $defaults->{$configtextvar}['format'] = @$this->block->config->format;
                 }

--- a/lib.php
+++ b/lib.php
@@ -34,16 +34,21 @@ function block_rolespecifichtml_pluginfile($course, $birecord_or_cm, $context, $
 
     require_course_login($course);
 
-    if ($filearea !== 'content') {
+    if (substr($filearea,0,8) !== 'content_')) {
         send_file_not_found();
     }
+    $role = substr($filearea,8);
+    if (!$role){
+        send_file_not_found();
+    }
+    //TODO check if user should have access
 
     $fs = get_file_storage();
 
     $filename = array_pop($args);
     $filepath = $args ? '/'.implode('/', $args).'/' : '/';
 
-    if (!$file = $fs->get_file($context->id, 'block_rolespecifichtml', 'content', 0, $filepath, $filename) or $file->is_directory()) {
+    if (!$file = $fs->get_file($context->id, 'block_rolespecifichtml', $filearea, 0, $filepath, $filename) or $file->is_directory()) {
         send_file_not_found();
     }
 

--- a/lib.php
+++ b/lib.php
@@ -60,7 +60,7 @@ function block_rolespecifichtml_pluginfile($course, $birecord_or_cm, $context, $
         $forcedownload = true;
     }
 
-    session_get_instance()->write_close();
+    \core\session\manager::write_close();
     send_stored_file($file, 60*60, 0, $forcedownload);
 }
 

--- a/lib.php
+++ b/lib.php
@@ -34,7 +34,7 @@ function block_rolespecifichtml_pluginfile($course, $birecord_or_cm, $context, $
 
     require_course_login($course);
 
-    if (substr($filearea,0,8) !== 'content_')) {
+    if (substr($filearea,0,8) !== 'content_') {
         send_file_not_found();
     }
     $role = substr($filearea,8);


### PR DESCRIPTION
Fixes a typo in the saving of pluginfiles where a t was between rolespecific and html.
Updates deprecated function call.
Splits common file area into multiple separate file areas for each role.
This fixes #2.

TODO: Check if user should have access to the file area, to prevent students accessing files meant for instructors.
Done in my fork, but relies upon changes made to roles (#8) so it knows what context to check, so it doesn't make sense without that pull request as well.